### PR TITLE
Bugfix on Vendor information display for product details page

### DIFF
--- a/includes/wc-template.php
+++ b/includes/wc-template.php
@@ -52,10 +52,18 @@ function dokan_product_seller_tab( $val ) {
     $author     = get_user_by( 'id', $product->post->post_author );
     $store_info = dokan_get_store_info( $author->ID );
 
-    dokan_get_template_part('global/product-tab', '', array(
-        'author' => $author,
-        'store_info' => $store_info,
-    ) );
+    if ($author) {
+        dokan_get_template_part(
+            'global/product-tab',
+            '',
+            [
+                'author'     => $author,
+                'store_info' => $store_info,
+            ]
+        );
+    } else {
+        echo "No vendor information found!";
+    }
 }
 
 


### PR DESCRIPTION
[Display no vendor found in case of author not found and return boolea](https://github.com/wp-plugins/dokan-lite/commit/657c6118cd269e3f29c2cddb3271e530809af7e3)